### PR TITLE
File patterns listed in .stasisignore are ignored ala .gitignore

### DIFF
--- a/lib/stasis.rb
+++ b/lib/stasis.rb
@@ -107,6 +107,13 @@ class Stasis
         false
       end
     end
+
+    # Reject paths that match the patterns in .stasisignore
+    if File.exists?(ignorefile = File.join(@root, ".stasisignore"))
+      File.open(ignorefile).each do |pattern|
+        @paths -= Dir[File.join(@root, pattern.chomp)]
+      end
+    end
   end
 
   def render(*only)


### PR DESCRIPTION
Just like it says, patterns are loaded from a .stasisignore file and excluded from the compilation - so

``` psd/**/*
```

Will exclude the directory psd and all subdirectories and files.

While

``` Gemfile*
```

Will exclude Gemfile and Gemfile.lock from being compiled into public/
