### PR TITLE
Add ability to pass options to template engine

### DIFF
--- a/lib/stasis.rb
+++ b/lib/stasis.rb
@@ -32,6 +32,7 @@ $:.unshift File.dirname(__FILE__)
 # Require all Stasis library files.
 
 require 'stasis/dev_mode'
+require 'stasis/options'
 require 'stasis/plugin'
 require 'stasis/server'
 
@@ -186,7 +187,8 @@ class Stasis
           # path, receive output from `@action._render`.
           #
           # Otherwise, render the file located at `@path`.
-          output = @action._render || @action.render(@path, :callback => false)
+          render_opts = {:callback => false}.merge(:template => Options.get_template_option(ext))
+          output = @action._render || @action.render(@path, render_opts)
 
           # If a layout was specified via the `layout` method...
           if @action._layout

--- a/lib/stasis/options.rb
+++ b/lib/stasis/options.rb
@@ -1,0 +1,21 @@
+class Stasis
+  class Options
+
+    @@template_options = Hash.new
+
+    # Set template engine options.
+    #
+    # type: string, template extension, e.g 'haml'
+    # opts: hash, template options
+    def self.set_template_option(type, opts={})
+        @@template_options[type] = opts
+    end
+
+    # Retrieve template engine options if available.
+    # Returns empty hash if no options set.
+    def self.get_template_option(type)
+        @@template_options[type] || {}
+    end
+
+  end
+end

--- a/lib/stasis/plugins/render.rb
+++ b/lib/stasis/plugins/render.rb
@@ -22,6 +22,7 @@ class Stasis
       path = options[:path]
       scope = options[:scope]
       text = options[:text]
+      template_options = options[:template]
 
       if @stasis.controller
         path = @stasis.controller._resolve(path)
@@ -41,7 +42,7 @@ class Stasis
           output =
             if Tilt.mappings.keys.include?(File.extname(path)[1..-1])
               scope = options[:scope] ||= @stasis.action
-              Tilt.new(path).render(scope, locals, &block)
+              Tilt.new(path, nil, template_options).render(scope, locals, &block)
             else
               File.read(path)
             end


### PR DESCRIPTION
This patch allows you to do the following in your controller.rb:

``` ruby
Stasis::Options.set_template_option 'haml', {:ugly => true}
```

The first argument is the template extension, the second argument is a hash of options to be passed to the templating engine.
