### PR TITLE
Implements Issue #39: Prints the view that was being rendered on an exception.

### DIFF
--- a/lib/stasis.rb
+++ b/lib/stasis.rb
@@ -183,7 +183,13 @@ class Stasis
           #
           # Otherwise, render the file located at `@path`.
           render_opts = {:callback => false}.merge(:template => Options.get_template_option(ext))
-          output = @action._render || @action.render(@path, render_opts)
+          begin
+            output = @action._render || @action.render(@path, render_opts)
+          rescue
+            # If rendering the view caused an exception write the path out before exiting.
+            puts "Exception rendering view #{@path}"
+            raise
+          end
 
           # If a layout was specified via the `layout` method...
           if @action._layout


### PR DESCRIPTION
This catches any exceptions that are thrown when a view is rendered and prints the file path. This is necessary because Coffeescript only indicates the line number but not the file name when an exception is thrown making it difficult/tedious/annoying to debug.
