### PR TITLE
fix for issue #18

### DIFF
--- a/bin/stasis
+++ b/bin/stasis
@@ -24,7 +24,7 @@ elsif slop.only?
 elsif slop.server?
   Stasis::Server.new(Dir.pwd, options)
 elsif slop.public?
-  Stasis.new(Dir.pwd, slop[:public], options).render(*slop[:only])
+  Stasis.new(Dir.pwd, slop[:public], options).render(*(slop[:only].to_a))
 else
   Stasis.new(Dir.pwd, options).render
 end


### PR DESCRIPTION
I tracked this down to what's apparently a bug in Ruby. `bin/stasis` takes the `-o/--only` argument from Slop and [splats it into the call to Stasis#render](https://github.com/winton/stasis/blob/v0.1.18/bin/stasis#L27). But observe what happens when you splat-expand nil:

```
>> def args(*arr); arr; end
=> nil
>> arr = nil
=> nil
>> args(*arr)
=> [nil]
```

Thus it happens that `#render` is being called with an explicit nil argument, making the path expansion explode with the backtrace listed in issue #18. Explicitly converting the `-o/--only` argument to an array before passing it to `#render` solves the issue.
