### PR TITLE
Render options are now passed when rendering layout.

### DIFF
--- a/lib/stasis.rb
+++ b/lib/stasis.rb
@@ -206,7 +206,7 @@ class Stasis
           # If a layout was specified via the `layout` method...
           if @action._layout
             # Render the layout with a block for the layout to `yield` to.
-            @action.render(@action._layout) { output }
+            @action.render(@action._layout, render_opts) { output }
           # If a layout was not specified...
           else
             output


### PR DESCRIPTION
Hey. I'm pretty new to Ruby so please make sure this won't brake anything.

I noticed that when I had a layout defined using layout 'layout.html.haml' in my controller.rb the template options I'd set weren't getting used. After digging through the code I believe I found the answer.

Bug:
Create a controller.rb with the following:
Options.set_template_option("haml", {:format => :html5})
layout 'layout.html.haml'

Create the layout file:
!!!
  %html
[etc...]

Create a page to use the layout and run stasis.

Expected Output:
<!doctype html>
<html>
[etc...]

Actual:
<!DOCTYPE html PUBLIC "-//W3C ...
<html>
[etc...]
