### PR TITLE
fix for issue #48

### DIFF
--- a/lib/stasis.rb
+++ b/lib/stasis.rb
@@ -94,7 +94,7 @@ class Stasis
 
     # Reject paths that are directories or within the destination directory.
     @paths.reject! do |path|
-      !File.file?(path) || path[0..@destination.length-1] == @destination
+      !File.file?(path) || path[0..@destination.length] == @destination+'/'
     end
 
     # Reject paths that are controllers.


### PR DESCRIPTION
Pull request as promised. This now excludes files that start with `public/` instead of `public`, which makes a file like `publications.html.haml` a valid template. (or any other @destination if given)
