### PR TITLE
Remove Dir.chdir calls from Stasis and Stasis::Controller

### DIFF
--- a/lib/stasis.rb
+++ b/lib/stasis.rb
@@ -183,9 +183,6 @@ class Stasis
       # Skip if `@path` set to `nil`.
       next unless @path
 
-      # Change current working directory.
-      Dir.chdir(File.dirname(@path))
-
       # Render the view.
       view =
         # If the path has an extension supported by [Tilt][ti]...

--- a/lib/stasis/scope/controller.rb
+++ b/lib/stasis/scope/controller.rb
@@ -23,9 +23,6 @@ class Stasis
       # Temporarily set path variables.
       @_stasis.path = path
 
-      # Change current working directory.
-      Dir.chdir(File.dirname(path))
-      
       # Evaluate `controller.rb`.
       instance_eval(File.read(path), path)
 


### PR DESCRIPTION
This wreaks havoc if you are embedding Stasis for HTML generation within a larger generation process, e.g., generating static blog entries like:

```ruby
Article.all.each do |article|
  stasis = Stasis.new("templates/", "public/articles/#{article.id}")
  stasis.render("article.html.haml", params: { article: article })
end
```

This will fail on the second iteration, since the current directory will now be "templates/"!

Having removed the calls to chdir, all the specs continue to pass, as well as my own generator specs. Is there a reason why this might break something else?