### PR TITLE
Additional mime type via CLI in development mode. (SVG not displayed, mimetype in webrick missing)

### DIFF
--- a/bin/stasis
+++ b/bin/stasis
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 
 require File.expand_path(File.dirname(__FILE__) + "/../lib/stasis")
-
 gem "slop", "3.3.2"
 require 'slop'
 
@@ -9,10 +8,12 @@ slop = Slop.parse :help => true, :optional_arguments => true do
   on :d, :development, "Development mode", :as => Integer
   on :o, :only, "Only generate specific files (comma-separated)", :as => Array
   on :p, :public, "Public directory path"
+  on :m, :mime_types, "Additional Mime Types", :as => Array
 end
 
 exit if slop.help?
 options = slop.to_hash
+options[:mime_types] = Hash[*options[:mime_types]]
 
 if slop.development?
   require 'stasis/dev_mode'

--- a/lib/stasis/dev_mode.rb
+++ b/lib/stasis/dev_mode.rb
@@ -42,8 +42,16 @@ class Stasis
 
       if @options[:development].is_a?(::Integer)
         mime_types = WEBrick::HTTPUtils::DefaultMimeTypes
-        mime_types.store 'js', 'application/javascript'
+
+        additional_mime_types = @options[:mime_types]
         
+        additional_mime_types.each do |extension, mimetype|
+          mime_types.store extension, mimetype
+          puts "add mime type #{mimetype} with extension .#{extension}"
+        end
+
+        mime_types.store 'js', 'application/javascript'
+
         server  = WEBrick::HTTPServer.new(
           :AccessLog => [ nil, nil ],
           :DocumentRoot => @stasis.destination,


### PR DESCRIPTION
I use svg files in my css files. They are not display with the current webrick configuration due to the lack of a proper mime type configuration. There is currently no way to add additional mime types to the webrick configuration. I monkey patched additional mime type support in a local copy of the stasis gem. These are the code changes summarized in a pull request, perhaps it`s useful for somebody else or the project itself.

``` ruby
#New: CLI call example single stasis -d 3100 -m svg,image/svg+xml
#New: CLI call example multiple stasis -d 3100 -m svg,image/svg+xml,js, application/javascript

#changed in dev_mode.rb around line 48. mime_types are read via CLI.
#See Commit for the other changes regarding slop/CLI reading
additional_mime_types = @options[:mime_types]
additional_mime_types.each do |extension, mimetype|
  mime_types.store extension, mimetype
  puts "add mime type #{mimetype} with extension .#{extension}"
end
```
