### PR TITLE
auto-load Gemfile (if present)

### DIFF
--- a/bin/stasis
+++ b/bin/stasis
@@ -15,6 +15,12 @@ exit if slop.help?
 options = slop.to_hash
 options[:mime_types] = Hash[*options[:mime_types]]
 
+# Autoload Gemfile if present in pwd
+begin
+  require "bundler/setup"
+  Bundler.require
+rescue; end
+
 if slop.development?
   require 'stasis/dev_mode'
   Stasis::DevMode.new(Dir.pwd, options)


### PR DESCRIPTION
Many of the demo stasis projects I've seen include a Gemfile. This patches the `stasis` executable to auto-load the gems listed in the Gemfile into the project. It's in a rescue block, and if no Gemfile is present then no errors rise.

Currently, (I think) the standard approach would be to explicitly require haml, scss, etc in a top level controller, or include the two lines `require "bundler/setup"; Bundler.require` in a top level controller. This patch makes including those requires unnecessary.
