### PR TITLE
Adds autocreate option for slop.

### DIFF
--- a/bin/stasis
+++ b/bin/stasis
@@ -4,7 +4,7 @@ require File.expand_path(File.dirname(__FILE__) + "/../lib/stasis")
 gem "slop", "3.3.2"
 require 'slop'
 
-slop = Slop.parse :help => true, :optional_arguments => true do
+slop = Slop.parse :autocreate => true, :help => true, :optional_arguments => true do
   on :d, :development, "Development mode", :as => Integer
   on :o, :only, "Only generate specific files (comma-separated)", :as => Array
   on :p, :public, "Public directory path"


### PR DESCRIPTION
"Adds autocreate option for slop. Allows user define options for their own needs on controller"

Guys, please take a look at this and see if it "hurts" any principle you might have created for stasis.

I'm in a situation now on which I would like to generate the static files differently passing different option, I want to create a few internationalization variances. With this change I'm proposing I could do:

`stasis --locale=pt-BR`

And on my controller I can do some logic and use different static files os different strings depending on the locale user passed on the execution.
